### PR TITLE
[FIX] openacademy: fix reports template

### DIFF
--- a/openacademy/__manifest__.py
+++ b/openacademy/__manifest__.py
@@ -31,7 +31,7 @@
         'views/session.xml',
         'views/wizard.xml',
         'security/ir.model.access.csv',
-        'views/reports.xml',
+        'reports/reports.xml',
         #'views/session_board.xml',
     ],
     # only loaded in demonstration mode

--- a/openacademy/models/session.py
+++ b/openacademy/models/session.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #import pdb;
 
-from odoo import models, fields, api, exceptions
+from odoo import models, fields, api, exceptions, _
 import time
 from psycopg2 import IntegrityError
 from datetime import timedelta

--- a/openacademy/reports/reports.xml
+++ b/openacademy/reports/reports.xml
@@ -1,9 +1,9 @@
 <odoo>
     <report id="report_session" model="openacademy.session" string="Session Report" name="openacademy.report_session_view" file="openacademy.report_session" report_type="qweb-pdf" />
     <template id="report_session_view">
-        <t t-call="report.html_container">
+        <t t-call="web.html_container">
             <t t-foreach="docs" t-as="doc">
-                <t t-call="report.external_layout">
+                <t t-call="web.external_layout">
                     <div class="page">
                         <h2 t-field="doc.name"/>
                         <p>From <span t-field="doc.start_date"/> to <span t-field="doc.end_date"/></p>


### PR DESCRIPTION
Now you can create a report. 
Probably the problem was the version of the tutorial, for 11.0 you need to use "web.html_container" to make the calls for qweb

For more information check https://www.odoo.com/documentation/11.0/howtos/backend.html#reporting


